### PR TITLE
make: fix default target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MKNOD := mknod
 INSMOD := insmod
 RMMOD := rmmod
 
-defalut:
+default:
 	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules
 
 load:


### PR DESCRIPTION
This PR fixes a type for the `default` target in the Makefile, previously called `defalut`.

Cheers